### PR TITLE
Expose basic GraphQL schema based on data model

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -9,3 +9,15 @@ generates:
       - "typescript-resolvers"
     config:
       useIndexSignature: true
+      mappers:
+        GameArena: ../../models/index.js#GameArena as GameArenaModel
+        GamePhase: ../../models/index.js#GamePhase as GamePhaseModel
+        GamePieceAction: ../../models/index.js#GamePieceAction as GamePieceActionModel
+        GamePiece: ../../models/index.js#GamePiece as GamePieceModel
+        GamePlayer: ../../models/index.js#GamePlayer as GamePlayerModel
+        Game: ../../models/index.js#Game as GameModel
+        PlayerUnit: ../../models/index.js#PlayerUnit as PlayerUnitModel
+        Player: ../../models/index.js#Player as PlayerModel
+        Unit: ../../models/index.js#Unit as UnitModel
+        GamePhaseName: ../../models/game_phase.js#GamePhaseName as GamePhaseNameModel
+        GamePieceActionData: ../../models/game_piece_action.js#GamePieceActionData as GamePieceActionDataModel

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,15 +39,3 @@ console.log(`Server running on port ${webPort}`);
 // See https://sequelize.org/v5/manual/models-usage.html#data-retrieval---finders
 import { Player, Unit, PlayerUnit, Game, GamePlayer, GamePiece, GamePieceAction, GamePhase } from './models/index.js';
 import { GamePieceMoveAction } from './models/game_piece_action.js';
-
-var players = await Player.findAll();
-console.log('players.length = ' + players.length);
-console.log('listing players...');
-players.forEach(player => {
-  console.log(`id: ${player.id}, name: ${player.name}, minaPublicKey: ${player.minaPublicKey}`);
-});
-
-// Another example, creating a record
-// await Player.create({ name: 'New Guy', minaPublicKey: 'somekey' });
-// var createdPlayer = await Player.findOne({ where: { name: 'New Guy' }});
-// console.log(`id of created Player is ${createdPlayer.id}`);

--- a/src/graphql/__generated__/resolvers-types.ts
+++ b/src/graphql/__generated__/resolvers-types.ts
@@ -1,9 +1,14 @@
-import { GraphQLResolveInfo } from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import { GameArena as GameArenaModel, GamePhase as GamePhaseModel, GamePieceAction as GamePieceActionModel, GamePiece as GamePieceModel, GamePlayer as GamePlayerModel, Game as GameModel, PlayerUnit as PlayerUnitModel, Player as PlayerModel, Unit as UnitModel } from '../../models/index.js';
+import { GamePhaseName as GamePhaseNameModel } from '../../models/game_phase.js';
+import { GamePieceActionData as GamePieceActionDataModel } from '../../models/game_piece_action.js';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type EnumResolverSignature<T, AllowedValues = any> = { [key in keyof T]?: AllowedValues };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -12,54 +17,195 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  Iso8601DateTime: any;
 };
 
-export type Message = {
-  __typename?: 'Message';
-  author?: Maybe<Scalars['String']>;
-  content?: Maybe<Scalars['String']>;
+export type CreateGameInput = {
+  arenaHeight: Scalars['Int'];
+  arenaWidth: Scalars['Int'];
+};
+
+export type CreatePlayerUnitInput = {
+  name: Scalars['String'];
+  unitId: Scalars['Int'];
+};
+
+export type Game = {
+  __typename?: 'Game';
+  arena?: Maybe<GameArena>;
+  createdAt: Scalars['Iso8601DateTime'];
+  currentPhase?: Maybe<GamePhase>;
+  gamePhases: Array<GamePhase>;
+  gamePieces: Array<GamePiece>;
+  gamePlayers: Array<GamePlayer>;
   id: Scalars['ID'];
+  status: GameStatus;
+  turnGamePlayer?: Maybe<GamePlayer>;
+  turnNumber?: Maybe<Scalars['Int']>;
+  turnPlayerOrder: Array<GamePlayer>;
+  updatedAt: Scalars['Iso8601DateTime'];
+  winningGamePlayer?: Maybe<GamePlayer>;
 };
 
-export type MessageInput = {
-  author?: InputMaybe<Scalars['String']>;
-  content?: InputMaybe<Scalars['String']>;
+export type GameArena = {
+  __typename?: 'GameArena';
+  createdAt: Scalars['Iso8601DateTime'];
+  game: Game;
+  height: Scalars['Int'];
+  id: Scalars['ID'];
+  updatedAt: Scalars['Iso8601DateTime'];
+  width: Scalars['Int'];
 };
+
+export type GamePhase = {
+  __typename?: 'GamePhase';
+  createdAt: Scalars['Iso8601DateTime'];
+  game: Game;
+  gamePieceActions: Array<GamePieceAction>;
+  gamePlayer: GamePlayer;
+  id: Scalars['ID'];
+  name: GamePhaseName;
+  turnNumber: Scalars['Int'];
+  updatedAt: Scalars['Iso8601DateTime'];
+};
+
+export enum GamePhaseName {
+  Melee = 'MELEE',
+  Movement = 'MOVEMENT',
+  Shooting = 'SHOOTING'
+}
+
+export type GamePiece = {
+  __typename?: 'GamePiece';
+  coordinates?: Maybe<GamePieceCoordinates>;
+  createdAt: Scalars['Iso8601DateTime'];
+  game: Game;
+  gamePieceActions: Array<GamePieceAction>;
+  gamePlayer: GamePlayer;
+  health: Scalars['Int'];
+  id: Scalars['ID'];
+  playerUnit: PlayerUnit;
+  updatedAt: Scalars['Iso8601DateTime'];
+};
+
+export type GamePieceAction = {
+  __typename?: 'GamePieceAction';
+  actionData: GamePieceActionData;
+  actionType: GamePieceActionType;
+  createdAt: Scalars['Iso8601DateTime'];
+  gamePhase: GamePhase;
+  gamePiece: GamePiece;
+  gamePlayer: GamePlayer;
+  id: Scalars['ID'];
+  updatedAt: Scalars['Iso8601DateTime'];
+};
+
+export type GamePieceActionData = GamePieceMeleeAttackAction | GamePieceMoveAction | GamePieceRangedAttackAction;
+
+export enum GamePieceActionType {
+  MeleeAttack = 'MELEE_ATTACK',
+  Move = 'MOVE',
+  RangedAttack = 'RANGED_ATTACK'
+}
+
+export type GamePieceCoordinates = {
+  __typename?: 'GamePieceCoordinates';
+  x: Scalars['Int'];
+  y: Scalars['Int'];
+};
+
+export type GamePieceMeleeAttackAction = {
+  __typename?: 'GamePieceMeleeAttackAction';
+  targetGamePiece: GamePiece;
+};
+
+export type GamePieceMoveAction = {
+  __typename?: 'GamePieceMoveAction';
+  moveFrom: GamePieceCoordinates;
+  moveTo: GamePieceCoordinates;
+};
+
+export type GamePieceRangedAttackAction = {
+  __typename?: 'GamePieceRangedAttackAction';
+  targetGamePiece: GamePiece;
+};
+
+export type GamePlayer = {
+  __typename?: 'GamePlayer';
+  createdAt: Scalars['Iso8601DateTime'];
+  game: Game;
+  gamePhases: Array<GamePhase>;
+  gamePieceActions: Array<GamePieceAction>;
+  id: Scalars['ID'];
+  player: Player;
+  playerNumber: Scalars['Int'];
+  updatedAt: Scalars['Iso8601DateTime'];
+};
+
+export enum GameStatus {
+  Canceled = 'CANCELED',
+  Completed = 'COMPLETED',
+  InProgress = 'IN_PROGRESS',
+  Pending = 'PENDING'
+}
 
 export type Mutation = {
   __typename?: 'Mutation';
-  createMessage?: Maybe<Message>;
-  updateMessage?: Maybe<Message>;
+  createGame?: Maybe<Game>;
 };
 
 
-export type MutationCreateMessageArgs = {
-  input?: InputMaybe<MessageInput>;
+export type MutationCreateGameArgs = {
+  input: CreateGameInput;
 };
 
-
-export type MutationUpdateMessageArgs = {
+export type Player = {
+  __typename?: 'Player';
+  createdAt: Scalars['Iso8601DateTime'];
   id: Scalars['ID'];
-  input?: InputMaybe<MessageInput>;
+  minaPublicKey: Scalars['String'];
+  name: Scalars['String'];
+  updatedAt: Scalars['Iso8601DateTime'];
+};
+
+export type PlayerUnit = {
+  __typename?: 'PlayerUnit';
+  createdAt: Scalars['Iso8601DateTime'];
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  player: Player;
+  unit: Unit;
+  updatedAt: Scalars['Iso8601DateTime'];
 };
 
 export type Query = {
   __typename?: 'Query';
-  getMessage?: Maybe<Message>;
-  quoteOfTheDay?: Maybe<Scalars['String']>;
-  random: Scalars['Float'];
-  rollDice?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  game?: Maybe<Game>;
+  games: Array<Game>;
+  unit?: Maybe<Unit>;
+  units: Array<Unit>;
 };
 
 
-export type QueryGetMessageArgs = {
+export type QueryGameArgs = {
   id: Scalars['ID'];
 };
 
 
-export type QueryRollDiceArgs = {
-  numDice: Scalars['Int'];
-  numSides?: InputMaybe<Scalars['Int']>;
+export type QueryUnitArgs = {
+  id: Scalars['ID'];
+};
+
+export type Unit = {
+  __typename?: 'Unit';
+  armor: Scalars['Int'];
+  attackPower: Scalars['Int'];
+  createdAt: Scalars['Iso8601DateTime'];
+  id: Scalars['ID'];
+  maxHealth: Scalars['Int'];
+  movementSpeed: Scalars['Int'];
+  name: Scalars['String'];
+  updatedAt: Scalars['Iso8601DateTime'];
 };
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
@@ -133,51 +279,228 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Float: ResolverTypeWrapper<Scalars['Float']>;
+  CreateGameInput: CreateGameInput;
+  CreatePlayerUnitInput: CreatePlayerUnitInput;
+  Game: ResolverTypeWrapper<GameModel>;
+  GameArena: ResolverTypeWrapper<GameArenaModel>;
+  GamePhase: ResolverTypeWrapper<GamePhaseModel>;
+  GamePhaseName: ResolverTypeWrapper<GamePhaseNameModel>;
+  GamePiece: ResolverTypeWrapper<GamePieceModel>;
+  GamePieceAction: ResolverTypeWrapper<GamePieceActionModel>;
+  GamePieceActionData: ResolverTypeWrapper<GamePieceActionDataModel>;
+  GamePieceActionType: GamePieceActionType;
+  GamePieceCoordinates: ResolverTypeWrapper<GamePieceCoordinates>;
+  GamePieceMeleeAttackAction: ResolverTypeWrapper<Omit<GamePieceMeleeAttackAction, 'targetGamePiece'> & { targetGamePiece: ResolversTypes['GamePiece'] }>;
+  GamePieceMoveAction: ResolverTypeWrapper<GamePieceMoveAction>;
+  GamePieceRangedAttackAction: ResolverTypeWrapper<Omit<GamePieceRangedAttackAction, 'targetGamePiece'> & { targetGamePiece: ResolversTypes['GamePiece'] }>;
+  GamePlayer: ResolverTypeWrapper<GamePlayerModel>;
+  GameStatus: GameStatus;
   ID: ResolverTypeWrapper<Scalars['ID']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
-  Message: ResolverTypeWrapper<Message>;
-  MessageInput: MessageInput;
+  Iso8601DateTime: ResolverTypeWrapper<Scalars['Iso8601DateTime']>;
   Mutation: ResolverTypeWrapper<{}>;
+  Player: ResolverTypeWrapper<PlayerModel>;
+  PlayerUnit: ResolverTypeWrapper<PlayerUnitModel>;
   Query: ResolverTypeWrapper<{}>;
   String: ResolverTypeWrapper<Scalars['String']>;
+  Unit: ResolverTypeWrapper<UnitModel>;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean'];
-  Float: Scalars['Float'];
+  CreateGameInput: CreateGameInput;
+  CreatePlayerUnitInput: CreatePlayerUnitInput;
+  Game: GameModel;
+  GameArena: GameArenaModel;
+  GamePhase: GamePhaseModel;
+  GamePiece: GamePieceModel;
+  GamePieceAction: GamePieceActionModel;
+  GamePieceActionData: GamePieceActionDataModel;
+  GamePieceCoordinates: GamePieceCoordinates;
+  GamePieceMeleeAttackAction: Omit<GamePieceMeleeAttackAction, 'targetGamePiece'> & { targetGamePiece: ResolversParentTypes['GamePiece'] };
+  GamePieceMoveAction: GamePieceMoveAction;
+  GamePieceRangedAttackAction: Omit<GamePieceRangedAttackAction, 'targetGamePiece'> & { targetGamePiece: ResolversParentTypes['GamePiece'] };
+  GamePlayer: GamePlayerModel;
   ID: Scalars['ID'];
   Int: Scalars['Int'];
-  Message: Message;
-  MessageInput: MessageInput;
+  Iso8601DateTime: Scalars['Iso8601DateTime'];
   Mutation: {};
+  Player: PlayerModel;
+  PlayerUnit: PlayerUnitModel;
   Query: {};
   String: Scalars['String'];
+  Unit: UnitModel;
 }>;
 
-export type MessageResolvers<ContextType = any, ParentType extends ResolversParentTypes['Message'] = ResolversParentTypes['Message']> = ResolversObject<{
-  author?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  content?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+export type GameResolvers<ContextType = any, ParentType extends ResolversParentTypes['Game'] = ResolversParentTypes['Game']> = ResolversObject<{
+  arena?: Resolver<Maybe<ResolversTypes['GameArena']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  currentPhase?: Resolver<Maybe<ResolversTypes['GamePhase']>, ParentType, ContextType>;
+  gamePhases?: Resolver<Array<ResolversTypes['GamePhase']>, ParentType, ContextType>;
+  gamePieces?: Resolver<Array<ResolversTypes['GamePiece']>, ParentType, ContextType>;
+  gamePlayers?: Resolver<Array<ResolversTypes['GamePlayer']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['GameStatus'], ParentType, ContextType>;
+  turnGamePlayer?: Resolver<Maybe<ResolversTypes['GamePlayer']>, ParentType, ContextType>;
+  turnNumber?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  turnPlayerOrder?: Resolver<Array<ResolversTypes['GamePlayer']>, ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  winningGamePlayer?: Resolver<Maybe<ResolversTypes['GamePlayer']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type GameArenaResolvers<ContextType = any, ParentType extends ResolversParentTypes['GameArena'] = ResolversParentTypes['GameArena']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  game?: Resolver<ResolversTypes['Game'], ParentType, ContextType>;
+  height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  width?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePhaseResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePhase'] = ResolversParentTypes['GamePhase']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  game?: Resolver<ResolversTypes['Game'], ParentType, ContextType>;
+  gamePieceActions?: Resolver<Array<ResolversTypes['GamePieceAction']>, ParentType, ContextType>;
+  gamePlayer?: Resolver<ResolversTypes['GamePlayer'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['GamePhaseName'], ParentType, ContextType>;
+  turnNumber?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePhaseNameResolvers = EnumResolverSignature<{ MELEE?: any, MOVEMENT?: any, SHOOTING?: any }, ResolversTypes['GamePhaseName']>;
+
+export type GamePieceResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePiece'] = ResolversParentTypes['GamePiece']> = ResolversObject<{
+  coordinates?: Resolver<Maybe<ResolversTypes['GamePieceCoordinates']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  game?: Resolver<ResolversTypes['Game'], ParentType, ContextType>;
+  gamePieceActions?: Resolver<Array<ResolversTypes['GamePieceAction']>, ParentType, ContextType>;
+  gamePlayer?: Resolver<ResolversTypes['GamePlayer'], ParentType, ContextType>;
+  health?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  playerUnit?: Resolver<ResolversTypes['PlayerUnit'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePieceActionResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePieceAction'] = ResolversParentTypes['GamePieceAction']> = ResolversObject<{
+  actionData?: Resolver<ResolversTypes['GamePieceActionData'], ParentType, ContextType>;
+  actionType?: Resolver<ResolversTypes['GamePieceActionType'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  gamePhase?: Resolver<ResolversTypes['GamePhase'], ParentType, ContextType>;
+  gamePiece?: Resolver<ResolversTypes['GamePiece'], ParentType, ContextType>;
+  gamePlayer?: Resolver<ResolversTypes['GamePlayer'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePieceActionDataResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePieceActionData'] = ResolversParentTypes['GamePieceActionData']> = ResolversObject<{
+  __resolveType: TypeResolveFn<'GamePieceMeleeAttackAction' | 'GamePieceMoveAction' | 'GamePieceRangedAttackAction', ParentType, ContextType>;
+}>;
+
+export type GamePieceCoordinatesResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePieceCoordinates'] = ResolversParentTypes['GamePieceCoordinates']> = ResolversObject<{
+  x?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  y?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePieceMeleeAttackActionResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePieceMeleeAttackAction'] = ResolversParentTypes['GamePieceMeleeAttackAction']> = ResolversObject<{
+  targetGamePiece?: Resolver<ResolversTypes['GamePiece'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePieceMoveActionResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePieceMoveAction'] = ResolversParentTypes['GamePieceMoveAction']> = ResolversObject<{
+  moveFrom?: Resolver<ResolversTypes['GamePieceCoordinates'], ParentType, ContextType>;
+  moveTo?: Resolver<ResolversTypes['GamePieceCoordinates'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePieceRangedAttackActionResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePieceRangedAttackAction'] = ResolversParentTypes['GamePieceRangedAttackAction']> = ResolversObject<{
+  targetGamePiece?: Resolver<ResolversTypes['GamePiece'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GamePlayerResolvers<ContextType = any, ParentType extends ResolversParentTypes['GamePlayer'] = ResolversParentTypes['GamePlayer']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  game?: Resolver<ResolversTypes['Game'], ParentType, ContextType>;
+  gamePhases?: Resolver<Array<ResolversTypes['GamePhase']>, ParentType, ContextType>;
+  gamePieceActions?: Resolver<Array<ResolversTypes['GamePieceAction']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  player?: Resolver<ResolversTypes['Player'], ParentType, ContextType>;
+  playerNumber?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export interface Iso8601DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Iso8601DateTime'], any> {
+  name: 'Iso8601DateTime';
+}
+
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
-  createMessage?: Resolver<Maybe<ResolversTypes['Message']>, ParentType, ContextType, Partial<MutationCreateMessageArgs>>;
-  updateMessage?: Resolver<Maybe<ResolversTypes['Message']>, ParentType, ContextType, RequireFields<MutationUpdateMessageArgs, 'id'>>;
+  createGame?: Resolver<Maybe<ResolversTypes['Game']>, ParentType, ContextType, RequireFields<MutationCreateGameArgs, 'input'>>;
+}>;
+
+export type PlayerResolvers<ContextType = any, ParentType extends ResolversParentTypes['Player'] = ResolversParentTypes['Player']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  minaPublicKey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PlayerUnitResolvers<ContextType = any, ParentType extends ResolversParentTypes['PlayerUnit'] = ResolversParentTypes['PlayerUnit']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  player?: Resolver<ResolversTypes['Player'], ParentType, ContextType>;
+  unit?: Resolver<ResolversTypes['Unit'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
-  getMessage?: Resolver<Maybe<ResolversTypes['Message']>, ParentType, ContextType, RequireFields<QueryGetMessageArgs, 'id'>>;
-  quoteOfTheDay?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  random?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  rollDice?: Resolver<Maybe<Array<Maybe<ResolversTypes['Int']>>>, ParentType, ContextType, RequireFields<QueryRollDiceArgs, 'numDice'>>;
+  game?: Resolver<Maybe<ResolversTypes['Game']>, ParentType, ContextType, RequireFields<QueryGameArgs, 'id'>>;
+  games?: Resolver<Array<ResolversTypes['Game']>, ParentType, ContextType>;
+  unit?: Resolver<Maybe<ResolversTypes['Unit']>, ParentType, ContextType, RequireFields<QueryUnitArgs, 'id'>>;
+  units?: Resolver<Array<ResolversTypes['Unit']>, ParentType, ContextType>;
+}>;
+
+export type UnitResolvers<ContextType = any, ParentType extends ResolversParentTypes['Unit'] = ResolversParentTypes['Unit']> = ResolversObject<{
+  armor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  attackPower?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  maxHealth?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  movementSpeed?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['Iso8601DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type Resolvers<ContextType = any> = ResolversObject<{
-  Message?: MessageResolvers<ContextType>;
+  Game?: GameResolvers<ContextType>;
+  GameArena?: GameArenaResolvers<ContextType>;
+  GamePhase?: GamePhaseResolvers<ContextType>;
+  GamePhaseName?: GamePhaseNameResolvers;
+  GamePiece?: GamePieceResolvers<ContextType>;
+  GamePieceAction?: GamePieceActionResolvers<ContextType>;
+  GamePieceActionData?: GamePieceActionDataResolvers<ContextType>;
+  GamePieceCoordinates?: GamePieceCoordinatesResolvers<ContextType>;
+  GamePieceMeleeAttackAction?: GamePieceMeleeAttackActionResolvers<ContextType>;
+  GamePieceMoveAction?: GamePieceMoveActionResolvers<ContextType>;
+  GamePieceRangedAttackAction?: GamePieceRangedAttackActionResolvers<ContextType>;
+  GamePlayer?: GamePlayerResolvers<ContextType>;
+  Iso8601DateTime?: GraphQLScalarType;
   Mutation?: MutationResolvers<ContextType>;
+  Player?: PlayerResolvers<ContextType>;
+  PlayerUnit?: PlayerUnitResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  Unit?: UnitResolvers<ContextType>;
 }>;
 

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -1,0 +1,7 @@
+export function camelToSnake(str) {
+  return str.replace(/[A-Z]/g, (c) => {return '_' + c.toLowerCase()});
+}
+
+export function camelToScreamingSnake(str) {
+  return camelToSnake(str).toUpperCase();
+}

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,22 +1,159 @@
 type Query {
-  getMessage(id: ID!): Message
-  quoteOfTheDay: String
-  random: Float!
-  rollDice(numDice: Int!, numSides: Int): [Int]
+  game(id: ID!): Game
+  games: [Game!]!
+  unit(id: ID!): Unit
+  units: [Unit!]!
 }
 
 type Mutation {
-  createMessage(input: MessageInput): Message
-  updateMessage(id: ID!, input: MessageInput): Message
+  createGame(input: CreateGameInput!): Game
 }
 
-input MessageInput {
-  content: String
-  author: String
+scalar Iso8601DateTime
+
+enum GameStatus {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+  CANCELED
 }
 
-type Message {
+enum GamePhaseName {
+  MOVEMENT
+  SHOOTING
+  MELEE
+}
+
+enum GamePieceActionType {
+  MOVE
+  RANGED_ATTACK
+  MELEE_ATTACK
+}
+
+type Player {
   id: ID!
-  content: String
-  author: String
+  name: String!
+  minaPublicKey: String!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type Game {
+  id: ID!
+  status: GameStatus!
+  arena: GameArena
+  turnNumber: Int
+  gamePlayers: [GamePlayer!]!
+  turnPlayerOrder: [GamePlayer!]!
+  turnGamePlayer: GamePlayer
+  winningGamePlayer: GamePlayer
+  gamePieces: [GamePiece!]!
+  gamePhases: [GamePhase!]!
+  currentPhase: GamePhase
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type GamePlayer {
+  id: ID!
+  game: Game!
+  player: Player!
+  playerNumber: Int!
+  gamePhases: [GamePhase!]!
+  gamePieceActions: [GamePieceAction!]!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type GameArena {
+  id: ID!
+  game: Game!
+  width: Int!
+  height: Int!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type Unit {
+  id: ID!
+  name: String!
+  attackPower: Int!
+  armor: Int!
+  maxHealth: Int!
+  movementSpeed: Int!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type PlayerUnit {
+  id: ID!
+  player: Player!
+  unit: Unit!
+  name: String!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type GamePiece {
+  id: ID!
+  game: Game!
+  gamePlayer: GamePlayer!
+  playerUnit: PlayerUnit!
+  coordinates: GamePieceCoordinates
+  health: Int!
+  gamePieceActions: [GamePieceAction!]!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type GamePieceCoordinates {
+  x: Int!
+  y: Int!
+}
+
+type GamePhase {
+  id: ID!
+  game: Game!
+  gamePlayer: GamePlayer!
+  turnNumber: Int!
+  name: GamePhaseName!
+  gamePieceActions: [GamePieceAction!]!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+type GamePieceAction {
+  id: ID!
+  gamePhase: GamePhase!
+  gamePlayer: GamePlayer!
+  gamePiece: GamePiece!
+  actionType: GamePieceActionType!
+  actionData: GamePieceActionData!
+  createdAt: Iso8601DateTime!
+  updatedAt: Iso8601DateTime!
+}
+
+union GamePieceActionData = GamePieceMoveAction | GamePieceRangedAttackAction | GamePieceMeleeAttackAction
+
+type GamePieceMoveAction {
+  moveFrom: GamePieceCoordinates!
+  moveTo: GamePieceCoordinates!
+}
+
+type GamePieceRangedAttackAction {
+  targetGamePiece: GamePiece!
+}
+
+type GamePieceMeleeAttackAction {
+  targetGamePiece: GamePiece!
+}
+
+input CreateGameInput {
+  arenaWidth: Int!
+  arenaHeight: Int!
+}
+
+input CreatePlayerUnitInput {
+  unitId: Int!
+  name: String!
 }

--- a/src/models/game_arena.ts
+++ b/src/models/game_arena.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 class GameArena extends Model<InferAttributes<GameArena>, InferCreationAttributes<GameArena>> {
   declare id: number;
@@ -8,6 +9,10 @@ class GameArena extends Model<InferAttributes<GameArena>, InferCreationAttribute
   declare height: number;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+
+  async game(): Promise<Models.Game> {
+    return await Models.Game.findByPk(this.gameId);
+  }
 }
 
 GameArena.init({

--- a/src/models/game_phase.ts
+++ b/src/models/game_phase.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 export type GamePhaseName = 'movement' | 'shooting' | 'melee';
 
@@ -11,6 +12,21 @@ class GamePhase extends Model<InferAttributes<GamePhase>, InferCreationAttribute
   declare phase: GamePhaseName;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+
+  async game(): Promise<Models.Game> {
+    return await Models.Game.findByPk(this.gameId);
+  }
+
+  async gamePlayer(): Promise<Models.GamePlayer> {
+    return await Models.GamePlayer.findByPk(this.gamePlayerId);
+  }
+
+  async gamePieceActions(): Promise<Models.GamePieceAction[]> {
+    return await Models.GamePieceAction.findAll({
+      where: { gamePhaseId: this.id },
+      order: [['id', 'ASC']]
+    });
+  }
 }
 
 GamePhase.init({

--- a/src/models/game_piece.ts
+++ b/src/models/game_piece.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 class GamePiece extends Model<InferAttributes<GamePiece>, InferCreationAttributes<GamePiece>> {
   declare id: CreationOptional<number>;
@@ -11,6 +12,18 @@ class GamePiece extends Model<InferAttributes<GamePiece>, InferCreationAttribute
   declare health: number;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+
+  async game(): Promise<Models.Game> {
+    return await Models.Game.findByPk(this.gameId);
+  }
+
+  async gamePlayer(): Promise<Models.GamePlayer> {
+    return await Models.GamePlayer.findByPk(this.gamePlayerId);
+  }
+
+  async playerUnit(): Promise<Models.PlayerUnit> {
+    return await Models.PlayerUnit.findByPk(this.playerUnitId);
+  }
 }
 
 GamePiece.init({

--- a/src/models/game_piece_action.ts
+++ b/src/models/game_piece_action.ts
@@ -1,12 +1,13 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 export type GamePieceActionType = 'move' | 'rangedAttack' | 'meleeAttack';
 
 export type GameArenaCoordinates = { x: number, y: number };
-export type GamePieceMoveAction = { actionType: 'move', data: { moveFrom: GameArenaCoordinates, moveTo: GameArenaCoordinates } };
-export type GamePieceRangedAttackAction = { actionType: 'rangedAttack', data: { targetGamePieceId: number } };
-export type GamePieceMeleeAttackAction = { actionType: 'meleeAttack', data: { targetGamePieceId: number } };
+export type GamePieceMoveAction = { actionType: 'move', moveFrom: GameArenaCoordinates, moveTo: GameArenaCoordinates };
+export type GamePieceRangedAttackAction = { actionType: 'rangedAttack', targetGamePieceId: number };
+export type GamePieceMeleeAttackAction = { actionType: 'meleeAttack', targetGamePieceId: number };
 export type GamePieceActionData = GamePieceMoveAction | GamePieceRangedAttackAction | GamePieceMeleeAttackAction;
 
 class GamePieceAction extends Model<InferAttributes<GamePieceAction>, InferCreationAttributes<GamePieceAction>> {
@@ -18,6 +19,18 @@ class GamePieceAction extends Model<InferAttributes<GamePieceAction>, InferCreat
   declare actionData: GamePieceActionData;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+
+  async gamePhase(): Promise<Models.GamePhase> {
+    return await Models.GamePhase.findByPk(this.gamePhaseId);
+  }
+
+  async gamePlayer(): Promise<Models.GamePlayer> {
+    return await Models.GamePlayer.findByPk(this.gamePlayerId);
+  }
+
+  async gamePiece(): Promise<Models.GamePiece> {
+    return await Models.GamePiece.findByPk(this.gamePieceId);
+  }
 }
 
 GamePieceAction.init({

--- a/src/models/game_player.ts
+++ b/src/models/game_player.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 class GamePlayer extends Model<InferAttributes<GamePlayer>, InferCreationAttributes<GamePlayer>> {
   declare id: number;
@@ -8,6 +9,14 @@ class GamePlayer extends Model<InferAttributes<GamePlayer>, InferCreationAttribu
   declare playerNumber: number;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+
+  async game(): Promise<Models.Game> {
+    return await Models.Game.findByPk(this.gameId);
+  }
+
+  async player(): Promise<Models.Player> {
+    return await Models.Player.findByPk(this.playerId);
+  }
 }
 
 GamePlayer.init({

--- a/src/models/player.ts
+++ b/src/models/player.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 class Player extends Model<InferAttributes<Player>, InferCreationAttributes<Player>> {
   declare id: number
@@ -8,6 +9,14 @@ class Player extends Model<InferAttributes<Player>, InferCreationAttributes<Play
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
   declare readonly deletedAt: Date;
+
+  async playerUnits(): Promise<Models.PlayerUnit[]> {
+    return await Models.PlayerUnit.findAll({ where: { playerId: this.id } });
+  }
+
+  async gamePlayers(): Promise<Models.GamePlayer[]> {
+    return await Models.GamePlayer.findAll({ where: { playerId: this.id } });
+  }
 }
 
 Player.init({

--- a/src/models/player_unit.ts
+++ b/src/models/player_unit.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 class PlayerUnit extends Model<InferAttributes<PlayerUnit>, InferCreationAttributes<PlayerUnit>> {
   declare id: number;
@@ -8,6 +9,18 @@ class PlayerUnit extends Model<InferAttributes<PlayerUnit>, InferCreationAttribu
   declare unitId: number;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+
+  async player(): Promise<Models.Player> {
+    return await Models.Player.findByPk(this.playerId);
+  }
+
+  async unit(): Promise<Models.Unit> {
+    return await Models.Unit.findByPk(this.unitId);
+  }
+
+  async gamePieces(): Promise<Models.GamePiece[]> {
+    return await Models.GamePiece.findAll({ where: { playerUnitId: this.id }});
+  }
 }
 
 PlayerUnit.init({

--- a/src/models/unit.ts
+++ b/src/models/unit.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import sequelizeConnection from '../db/config.js';
+import * as Models from './index.js';
 
 class Unit extends Model<InferAttributes<Unit>, InferCreationAttributes<Unit>> {
   declare id: number;
@@ -10,6 +11,10 @@ class Unit extends Model<InferAttributes<Unit>, InferCreationAttributes<Unit>> {
   declare movementSpeed: number;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+
+  async playerUnits(): Promise<Models.PlayerUnit[]> {
+    return await Models.PlayerUnit.findAll({ where: { unitId: this.id } });
+  }
 }
 
 Unit.init({


### PR DESCRIPTION
## Problem

#5 created the remaining models needed to represent game state, but our GraphQL schema still only has some dummy examples.

## Solution

- Add the models defined in #5 to the GraphQL schema.
- Update the GraphQL resolvers to power some simple queries.
  - This includes some resolvers for transforming certain fields, specifically fields which exist on the GraphQL type but not on the database table, for example virtual fields and associations.
- Update the model classes with some helper methods for resolving associations and some other things.

Example query 1, list GamePieces in a Game and their positions:
![Screen Shot 2023-02-25 at 4 41 22 PM](https://user-images.githubusercontent.com/8811423/221381131-59f7dbec-783d-453f-838b-a50ee7cd0e41.png)

Example query 2, list all GamePhases in a Game, along with all GamePieceActions in each GamePhase:
![Screen Shot 2023-02-25 at 4 43 39 PM](https://user-images.githubusercontent.com/8811423/221381143-5253ff75-c7ec-4846-b058-74e3c658e129.png)

## Notes

Some things this PR intentionally does not include yet:
- Pagination
- Client-specified sorting of list fields
- Client-specified filtering of list fields
