### PR TITLE
Add hooks to destroy associated models

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -37,5 +37,5 @@ console.log(`Server running on port ${webPort}`);
 
 // Example of how to query a table using Sequelize
 // See https://sequelize.org/v5/manual/models-usage.html#data-retrieval---finders
-import { Player, Unit, PlayerUnit, Game, GamePlayer, GamePiece, GamePieceAction, GamePhase } from './models/index.js';
+import * as Models from './models/index.js';
 import { GamePieceMoveAction } from './models/game_piece_action.js';

--- a/src/models/game.ts
+++ b/src/models/game.ts
@@ -111,6 +111,14 @@ Game.init({
     type: DataTypes.DATE,
   },
 }, {
+  hooks: {
+    afterDestroy: async (game, options) => {
+      await Models.GameArena.destroy({ where: { gameId: game.id }});
+      await Models.GamePhase.destroy({ where: { gameId: game.id }});
+      await Models.GamePiece.destroy({ where: { gameId: game.id }});
+      await Models.GamePlayer.destroy({ where: { gameId: game.id }});
+    }
+  },
   sequelize: sequelizeConnection
 });
 

--- a/src/models/game_phase.ts
+++ b/src/models/game_phase.ts
@@ -60,6 +60,11 @@ GamePhase.init({
     type: DataTypes.DATE,
   },
 }, {
+  hooks: {
+    afterDestroy: async (gamePhase, options) => {
+      await Models.GamePieceAction.destroy({ where: { gamePhaseId: gamePhase.id }});
+    }
+  },
   sequelize: sequelizeConnection
 });
 

--- a/src/models/game_piece.ts
+++ b/src/models/game_piece.ts
@@ -63,6 +63,11 @@ GamePiece.init({
     type: DataTypes.DATE,
   },
 }, {
+  hooks: {
+    afterDestroy: async (gamePiece, options) => {
+      await Models.GamePieceAction.destroy({ where: { gamePieceId: gamePiece.id }});
+    }
+  },
   sequelize: sequelizeConnection
 });
 

--- a/src/models/game_player.ts
+++ b/src/models/game_player.ts
@@ -46,6 +46,13 @@ GamePlayer.init({
     type: DataTypes.DATE,
   },
 }, {
+  hooks: {
+    afterDestroy: async (gamePlayer, options) => {
+      await Models.GamePhase.destroy({ where: { gamePlayerId: gamePlayer.id }});
+      await Models.GamePiece.destroy({ where: { gamePlayerId: gamePlayer.id }});
+      await Models.GamePieceAction.destroy({ where: { gamePlayerId: gamePlayer.id }});
+    }
+  },
   sequelize: sequelizeConnection
 });
 

--- a/src/models/player.ts
+++ b/src/models/player.ts
@@ -45,6 +45,12 @@ Player.init({
     type: DataTypes.DATE
   }
 }, {
+  hooks: {
+    afterDestroy: async (player, options) => {
+      await Models.PlayerUnit.destroy({ where: { playerId: player.id }});
+      await Models.GamePlayer.destroy({ where: { playerId: player.id }});
+    }
+  },
   sequelize: sequelizeConnection,
   paranoid: true
 });

--- a/src/models/player_unit.ts
+++ b/src/models/player_unit.ts
@@ -50,6 +50,11 @@ PlayerUnit.init({
     type: DataTypes.DATE,
   },
 }, {
+  hooks: {
+    afterDestroy: async (playerUnit, options) => {
+      await Models.GamePiece.destroy({ where: { playerUnitId: playerUnit.id }});
+    }
+  },
   sequelize: sequelizeConnection
 });
 

--- a/src/models/unit.ts
+++ b/src/models/unit.ts
@@ -56,6 +56,11 @@ Unit.init({
     type: DataTypes.DATE,
   },
 }, {
+  hooks: {
+    afterDestroy: async (unit, options) => {
+      await Models.PlayerUnit.destroy({ where: { unitId: unit.id }});
+    }
+  },
   sequelize: sequelizeConnection
 });
 


### PR DESCRIPTION
## Problem

We don't yet have hooks which ensure associated dependent models are destroyed when a record is destroyed. For example, if you destroy a `Game` record currently, all of its associated objects remain in the database, all of its `GamePhases`, `GamePlayers`, etc.

## Solution

Use sequelize hooks to implement cascading cleanup of dependent models upon destruction of a model.
