### PR TITLE
Adjust config for deployment to Heroku

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,3 @@ TEST_DB_HOST=localhost
 TEST_DB_NAME=skirmish_server_poc_test
 TEST_DB_USERNAME=postgres
 TEST_DB_PASSWORD=mydatabasepassword
-
-PROD_DB_HOST=localhost
-PROD_DB_NAME=skirmish_server_poc_production
-PROD_DB_USERNAME=postgres
-PROD_DB_PASSWORD=mydatabasepassword

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -4,38 +4,40 @@ dotenv.config();
 import { Sequelize, Dialect } from 'sequelize';
 
 const environment = process.env.NODE_ENV || 'development';
+let sequelizeConnection;
 
-var dbHost: string;
-var dbName: string;
-var dbUser: string;
-var dbPassword: string;
+if (environment == 'production') {
+  // In production we will connect to Postgres using
+  // the DATABASE_URL environment variable
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error(`DATABASE_URL environment variable is required to boot in production!`);
 
-if (environment == 'development') {
-  dbHost = process.env.DEV_DB_HOST || 'localhost';
-  dbName = process.env.DEV_DB_NAME || 'skirmish_server_poc_development';
-  dbUser = process.env.DEV_DB_USERNAME || 'postgres';
-  dbPassword = process.env.DEV_DB_PASSWORD;
-} else if (environment == 'test') {
-  dbHost = process.env.TEST_DB_HOST || 'localhost';
-  dbName = process.env.TEST_DB_NAME || 'skirmish_server_poc_test';
-  dbUser = process.env.TEST_DB_USERNAME || 'postgres';
-  dbPassword = process.env.TEST_DB_PASSWORD;
-} else if (environment == 'production') {
-  dbHost = process.env.PROD_DB_HOST;
-  dbName = process.env.PROD_DB_NAME;
-  dbUser = process.env.PROD_DB_USERNAME;
-  dbPassword = process.env.PROD_DB_PASSWORD;
+  sequelizeConnection = new Sequelize(process.env.DATABASE_URL);
 } else {
-  throw new Error(`Invalid NODE_ENV ${environment}, must be one of: [development, test, production]`);
+  var dbHost: string;
+  var dbName: string;
+  var dbUser: string;
+  var dbPassword: string;
+  
+  if (environment == 'development') {
+    dbHost = process.env.DEV_DB_HOST || 'localhost';
+    dbName = process.env.DEV_DB_NAME || 'skirmish_server_poc_development';
+    dbUser = process.env.DEV_DB_USERNAME || 'postgres';
+    dbPassword = process.env.DEV_DB_PASSWORD;
+  } else if (environment == 'test') {
+    dbHost = process.env.TEST_DB_HOST || 'localhost';
+    dbName = process.env.TEST_DB_NAME || 'skirmish_server_poc_test';
+    dbUser = process.env.TEST_DB_USERNAME || 'postgres';
+    dbPassword = process.env.TEST_DB_PASSWORD;
+  } else {
+    throw new Error(`Invalid NODE_ENV ${environment}, must be one of: [development, test, production]`);
+  }
+  
+  const dbDriver: Dialect = 'postgres';
+  sequelizeConnection = new Sequelize(dbName, dbUser, dbPassword, {
+    host: dbHost,
+    dialect: dbDriver
+  });
 }
-
-const dbDriver: Dialect = 'postgres';
-
-console.log('Connecting to database ' + dbName + ' as user: ' + dbUser);
-
-const sequelizeConnection = new Sequelize(dbName, dbUser, dbPassword, {
-  host: dbHost,
-  dialect: dbDriver
-});
 
 export default sequelizeConnection;


### PR DESCRIPTION
## Problem

In order to deploy this app to [heroku](https://dashboard.heroku.com/apps/mina-arena-server), it will need some small config.

## Solution

- Add a Procfile which defines how to run the web server
- Adjust the database connection config in production to connect using a `DATABASE_URL` env variable rather than the way we do in dev.
- Adjust .env.example

## Notes

none
