### PR TITLE
Add seeder for common units

### DIFF
--- a/src/db/seeders/20230319204523-units.js
+++ b/src/db/seeders/20230319204523-units.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.bulkInsert('Units', [
+        {
+          name: 'Spearman',
+          attackPower: 3,
+          armor: 1,
+          maxHealth: 4,
+          movementSpeed: 40,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        {
+          name: 'Swordsman',
+          attackPower: 4,
+          armor: 1,
+          maxHealth: 4,
+          movementSpeed: 45,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        {
+          name: 'Archer',
+          attackPower: 2,
+          armor: 0,
+          maxHealth: 2,
+          movementSpeed: 40,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        {
+          name: 'Light Cavalry',
+          attackPower: 3,
+          armor: 1,
+          maxHealth: 6,
+          movementSpeed: 100,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      ]);
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add commands to revert seed here.
+     *
+     * Example:
+     * await queryInterface.bulkDelete('People', null, {});
+     */
+  }
+};


### PR DESCRIPTION
## Problem

We should have a seeder for common units.

## Solution

Add a seeder which adds some common units.

Can be run like so:
```bash
$ npx sequelize-cli db:seed --seed ./src/db/seeders/20230319204523-units.js
```

## Notes

Before running this seed I cleared all `GamePieceActions`, `GamePieces`, `PlayerUnits`, and `Units` from my database in order to start fresh.

Prime @45930 
