### PR TITLE
adding dice roll decryptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 node_modules
 
 dist/*
+
+
+*.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "http": "^0.0.1-security",
-        "mina-arena-contracts": "^0.2.1",
+        "mina-arena-contracts": "^0.3",
         "newrelic": "^10.3.0",
         "pg": "^8.9.0",
         "sequelize": "^6.31.0"
@@ -9489,9 +9489,9 @@
       }
     },
     "node_modules/mina-arena-contracts": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.2.1.tgz",
-      "integrity": "sha512-vmUogtT5Y5qNSzqy3Orpn+18GDgy62A3ChxwnQPjJ05SmuMZB/jKzY/kNVDG9ajnP4u2BJgZJ1iL0ZtryWNCNg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.3.0.tgz",
+      "integrity": "sha512-7GWrBmeTcF0hx/S3UEwlBpMfal+bzOkEurCK+Q5+gWLhNmg4Yp7Wzys+2UFmO/mYjT25m4lp938SAwKIhVrIFA==",
       "peerDependencies": {
         "snarkyjs": "0.10.1"
       }
@@ -19599,9 +19599,9 @@
       "dev": true
     },
     "mina-arena-contracts": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.2.1.tgz",
-      "integrity": "sha512-vmUogtT5Y5qNSzqy3Orpn+18GDgy62A3ChxwnQPjJ05SmuMZB/jKzY/kNVDG9ajnP4u2BJgZJ1iL0ZtryWNCNg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mina-arena-contracts/-/mina-arena-contracts-0.3.0.tgz",
+      "integrity": "sha512-7GWrBmeTcF0hx/S3UEwlBpMfal+bzOkEurCK+Q5+gWLhNmg4Yp7Wzys+2UFmO/mYjT25m4lp938SAwKIhVrIFA==",
       "requires": {}
     },
     "minimalistic-assert": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "http": "^0.0.1-security",
-    "mina-arena-contracts": "^0.2.1",
+    "mina-arena-contracts": "^0.3",
     "newrelic": "^10.3.0",
     "pg": "^8.9.0",
     "sequelize": "^6.31.0"

--- a/src/models/game_piece_action.ts
+++ b/src/models/game_piece_action.ts
@@ -21,18 +21,18 @@ export type GamePieceMoveAction = {
 };
 export type GamePieceRangedAttackAction = {
   actionType: 'rangedAttack';
-  resolved: Boolean;
+  resolved: boolean;
   targetGamePieceId: number;
-  encodedDiceRolls: EncodedDiceRolls;
+  encodedDiceRolls: EncryptedDiceRolls;
   resolvedAttacks?: ResolvedAttack[];
   totalDamageDealt?: number;
   totalDamageAverage?: number;
 };
 export type GamePieceMeleeAttackAction = {
   actionType: 'meleeAttack';
-  resolved: Boolean;
+  resolved: boolean;
   targetGamePieceId: number;
-  encodedDiceRolls: EncodedDiceRolls;
+  encodedDiceRolls: EncryptedDiceRolls;
   resolvedAttacks?: ResolvedAttack[];
   totalDamageDealt?: number;
   totalDamageAverage?: number;
@@ -42,7 +42,7 @@ export type GamePieceActionData =
   | GamePieceRangedAttackAction
   | GamePieceMeleeAttackAction;
 
-export type EncodedDiceRolls = {
+export type EncryptedDiceRolls = {
   publicKey: { x: string; y: string };
   cipherText: string;
   signature: { r: string; s: string };
@@ -54,13 +54,13 @@ export type ResolvedAttack = {
   saveRoll: RollResult;
   damageDealt: number;
   averageDamage: number;
-}
+};
 
 export type RollResult = {
   roll: number;
   rollNeeded: number;
-  success: Boolean;
-}
+  success: boolean;
+};
 
 class GamePieceAction extends Model<
   InferAttributes<GamePieceAction>,

--- a/src/service_objects/game_piece_action_resolvers/attack_resolver.ts
+++ b/src/service_objects/game_piece_action_resolvers/attack_resolver.ts
@@ -1,6 +1,9 @@
 import * as Models from '../../models/index.js';
 import { diceRoll } from '../../graphql/helpers.js';
-import { EncodedDiceRolls, ResolvedAttack } from '../../models/game_piece_action.js';
+import {
+  EncryptedDiceRolls,
+  ResolvedAttack,
+} from '../../models/game_piece_action.js';
 
 export default function resolveAttacks(
   numAttacks: number,
@@ -9,7 +12,7 @@ export default function resolveAttacks(
   targetSaveRollStat: number,
   attackerArmorPiercingStat: number,
   attackerDamageStat: number,
-  encodedDiceRolls: EncodedDiceRolls
+  encodedDiceRolls: EncryptedDiceRolls
 ): ResolvedAttack[] {
   // TODO: Decode dice roll results using private key
   //  For now just simulate rolls here
@@ -17,7 +20,7 @@ export default function resolveAttacks(
 
   // Gather details of each attack and determine damage
   let attacks = [];
-  for (var i = 0; i < numAttacks; i++) {
+  for (let i = 0; i < numAttacks; i++) {
     const rollsOffset = i * 3;
     const hitRoll = decodedDiceRolls[rollsOffset];
     const woundRoll = decodedDiceRolls[rollsOffset + 1];
@@ -30,28 +33,36 @@ export default function resolveAttacks(
     const modifiedSave = targetSaveRollStat + armorPiercing;
     const saveRollSuccess = saveRoll >= modifiedSave;
 
-    const damageDealt = hitRollSuccess && woundRollSuccess && !saveRollSuccess ? attackerDamageStat : 0;
-    
-    const oddsOfHitting = ((7 - attackerHitRollStat) / 6);
-    const oddsOfWounding = ((7 - attackerWoundRollStat) / 6);
-    const oddsOfPassingArmorSave = (Math.max(7 - modifiedSave, 0) / 6);
-    const averageDamage = (oddsOfHitting * oddsOfWounding * (1 - oddsOfPassingArmorSave) * attackerDamageStat).toFixed(2);
+    const damageDealt =
+      hitRollSuccess && woundRollSuccess && !saveRollSuccess
+        ? attackerDamageStat
+        : 0;
+
+    const oddsOfHitting = (7 - attackerHitRollStat) / 6;
+    const oddsOfWounding = (7 - attackerWoundRollStat) / 6;
+    const oddsOfPassingArmorSave = Math.max(7 - modifiedSave, 0) / 6;
+    const averageDamage = (
+      oddsOfHitting *
+      oddsOfWounding *
+      (1 - oddsOfPassingArmorSave) *
+      attackerDamageStat
+    ).toFixed(2);
 
     attacks.push({
       hitRoll: {
         roll: hitRoll,
         rollNeeded: attackerHitRollStat,
-        success: hitRollSuccess
+        success: hitRollSuccess,
       },
       woundRoll: {
         roll: woundRoll,
         rollNeeded: attackerWoundRollStat,
-        success: woundRollSuccess
+        success: woundRollSuccess,
       },
       saveRoll: {
         roll: saveRoll,
         rollNeeded: modifiedSave,
-        success: saveRollSuccess
+        success: saveRollSuccess,
       },
       damageDealt: damageDealt,
       averageDamage: averageDamage,
@@ -63,7 +74,7 @@ export default function resolveAttacks(
 // Simulate the attack sequence
 function simulateDiceRolls(numAttacks: number): number[] {
   let rolls = [];
-  for (var i = 0; i < numAttacks; i++) {
+  for (let i = 0; i < numAttacks; i++) {
     rolls.push(diceRoll()); // hit roll
     rolls.push(diceRoll()); // wound roll
     rolls.push(diceRoll()); // save roll

--- a/src/service_objects/mina/dice_roll_encryption.ts
+++ b/src/service_objects/mina/dice_roll_encryption.ts
@@ -1,0 +1,53 @@
+import {
+  Encryption,
+  Group,
+  Field,
+  PrivateKey,
+  Signature,
+  PublicKey,
+} from 'snarkyjs';
+import { EncryptedDiceRolls } from '../../models/game_piece_action';
+import newrelic from 'newrelic';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// decrpyt a dice roll
+export const decryptRoll = (roll: EncryptedDiceRolls): number => {
+  const rngPublicKey = PublicKey.fromBase58(process.env.RNG_PUBLIC_KEY);
+  const signature = Signature.fromJSON(roll.signature);
+  const cipherText = roll.cipherText
+    .split(',')
+    .map((element) => Field(element));
+
+  // verifies that the known RNG provider signed a message containing
+  // 1 | 6 | cipherText
+  // Where 1 is the number of dice rolled and 6 is the number of sides on the dice
+  const signatureIsValid = signature
+    .verify(rngPublicKey, [Field(1), Field(6), ...cipherText])
+    .toBoolean();
+
+  if (!signatureIsValid) {
+    throw 'Invalid Signature';
+  }
+
+  if (cipherText.length !== 2) {
+    // This should never happen - it means the signature lied about the length of the content
+    throw 'Ciphertext must be of length 2';
+  }
+
+  const publicKey = Group.fromJSON(roll.publicKey);
+  const ct = {
+    publicKey,
+    cipherText,
+  };
+  const serverPrivateKey = PrivateKey.fromBase58(
+    process.env.SERVER_PRIVATE_KEY
+  );
+  const decrypted = Encryption.decrypt(ct, serverPrivateKey);
+  newrelic.recordCustomEvent('DiceRollDecryption', {
+    ciphertext: roll.cipherText,
+    decrypted: decrypted[0].toString(),
+  });
+  return Number(decrypted[0].toString());
+};

--- a/test/service_objects/game_piece_action_resolvers/attack_resolver.test.ts
+++ b/test/service_objects/game_piece_action_resolvers/attack_resolver.test.ts
@@ -1,5 +1,5 @@
 import resolveAttack from '../../../src/service_objects/game_piece_action_resolvers/attack_resolver';
-import { EncodedDiceRolls } from '../../../src/models/game_piece_action.js';
+import { EncryptedDiceRolls } from '../../../src/models/game_piece_action.js';
 
 describe('resolveAttack', () => {
   let numAttacks: number;
@@ -8,7 +8,7 @@ describe('resolveAttack', () => {
   let targetSaveRollStat: number;
   let attackerArmorPiercingStat: number;
   let attackerDamageStat: number;
-  let encodedDiceRolls: EncodedDiceRolls;
+  let encodedDiceRolls: EncryptedDiceRolls;
 
   beforeEach(async () => {
     numAttacks = 100;
@@ -21,7 +21,7 @@ describe('resolveAttack', () => {
     encodedDiceRolls = {
       publicKey: { x: 'xValue', y: 'yValue' },
       cipherText: 'secret',
-      signature: { r: 'rValue', s: 'sValue' }
+      signature: { r: 'rValue', s: 'sValue' },
     };
   });
 
@@ -36,18 +36,24 @@ describe('resolveAttack', () => {
       encodedDiceRolls
     );
     expect(resolvedAttacks.length).toBe(numAttacks);
-    resolvedAttacks.forEach(resolvedAttack => {
-      
+    resolvedAttacks.forEach((resolvedAttack) => {
       expect(resolvedAttack.hitRoll.rollNeeded).toBe(attackerHitRollStat);
       expect(resolvedAttack.woundRoll.rollNeeded).toBe(attackerWoundRollStat);
-      expect(resolvedAttack.saveRoll.rollNeeded).toBe(targetSaveRollStat + attackerArmorPiercingStat);
+      expect(resolvedAttack.saveRoll.rollNeeded).toBe(
+        targetSaveRollStat + attackerArmorPiercingStat
+      );
 
-      const oddsOfHitting = ((7 - attackerHitRollStat) / 6);
-      const oddsOfWounding = ((7 - attackerWoundRollStat) / 6);
+      const oddsOfHitting = (7 - attackerHitRollStat) / 6;
+      const oddsOfWounding = (7 - attackerWoundRollStat) / 6;
       const modifiedSave = targetSaveRollStat + attackerArmorPiercingStat;
-      const oddsOfPassingArmorSave = (Math.max(7 - modifiedSave, 0) / 6);
-      const expectedAverageDamage = (oddsOfHitting * oddsOfWounding * (1 - oddsOfPassingArmorSave) * attackerDamageStat).toFixed(2);
-      expect(resolvedAttack.averageDamage).toBe(expectedAverageDamage)
+      const oddsOfPassingArmorSave = Math.max(7 - modifiedSave, 0) / 6;
+      const expectedAverageDamage = (
+        oddsOfHitting *
+        oddsOfWounding *
+        (1 - oddsOfPassingArmorSave) *
+        attackerDamageStat
+      ).toFixed(2);
+      expect(resolvedAttack.averageDamage).toBe(expectedAverageDamage);
 
       if (resolvedAttack.hitRoll.roll >= attackerHitRollStat) {
         expect(resolvedAttack.hitRoll.success).toBe(true);
@@ -61,7 +67,10 @@ describe('resolveAttack', () => {
         expect(resolvedAttack.woundRoll.success).toBe(false);
         expect(resolvedAttack.damageDealt).toBe(0);
       }
-      if (resolvedAttack.saveRoll.roll >= (targetSaveRollStat + attackerArmorPiercingStat)) {
+      if (
+        resolvedAttack.saveRoll.roll >=
+        targetSaveRollStat + attackerArmorPiercingStat
+      ) {
         expect(resolvedAttack.saveRoll.success).toBe(true);
         expect(resolvedAttack.damageDealt).toBe(0);
       } else {

--- a/test/service_objects/mina/dice_roll_encryption.test.ts
+++ b/test/service_objects/mina/dice_roll_encryption.test.ts
@@ -1,0 +1,57 @@
+import { decryptRoll } from '../../../src/service_objects/mina/dice_roll_encryption';
+import { Field, PrivateKey, Encryption, Signature } from 'snarkyjs';
+import { EncryptedDiceRolls } from '../../../src/models/game_piece_action';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+describe('Dice Roll Decryption', () => {
+  const serverPrivateKey = PrivateKey.fromBase58(
+    process.env.SERVER_PRIVATE_KEY as string
+  );
+  const rngPrivateKey = PrivateKey.fromBase58(
+    process.env.RNG_PRIVATE_KEY as string
+  );
+  describe('roll one die', () => {
+    const encryption = Encryption.encrypt(
+      [Field(2)],
+      serverPrivateKey.toPublicKey()
+    );
+    const sig = Signature.create(rngPrivateKey, [
+      Field(1),
+      Field(6),
+      ...encryption.cipherText,
+    ]);
+    const encryptedRoll: EncryptedDiceRolls = {
+      publicKey: encryption.publicKey.toJSON(),
+      cipherText: encryption.cipherText.toString(),
+      signature: sig.toJSON(),
+    };
+
+    it('decrypts the roll', async () => {
+      const decrypted = decryptRoll(encryptedRoll);
+
+      expect(decrypted).toEqual(2);
+    });
+  });
+  describe('roll two dice', () => {
+    const encryption = Encryption.encrypt(
+      [Field(2), Field(3)],
+      serverPrivateKey.toPublicKey()
+    );
+    const sig = Signature.create(rngPrivateKey, [
+      Field(2),
+      Field(6),
+      ...encryption.cipherText,
+    ]);
+    const encryptedRoll: EncryptedDiceRolls = {
+      publicKey: encryption.publicKey.toJSON(),
+      cipherText: encryption.cipherText.toString(),
+      signature: sig.toJSON(),
+    };
+
+    it('Throws an error', async () => {
+      expect(() => decryptRoll(encryptedRoll)).toThrow('Invalid Signature');
+    });
+  });
+});


### PR DESCRIPTION
Prime: @louiswheeleriv 

Adding the service object which can decrypt dice rolls.  It expects that a roll is exactly one roll of a D6 for now.  As I mentioned in the frontend PR, a dice roll of 2 or more dice will have to be signed individually by the RNG server - we can't break the signed whole piece into parts once it has been created and signed.

Tests passing locally, but there's a new warning about new relic causing this: `Jest has detected the following 2 open handles potentially keeping Jest from exiting:`.  Seems like more of an annoyance than a problem.  I should probably be disableing new relic in dev/test somehow.